### PR TITLE
feat: rank contributions/items from members page and drop failed users

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ QiitaのOrganizationsのデータを集めるプロジェクト
 ### 実装機能一覧
 
 - Organizationsの全ユーザを指定した指標で集計してランキングする。指標は実行時の第2引数で切り替える。
-  - `followers`: フォロワー数（Qiita API）
-  - `contributions`: Contribution数（プロフィールページのスクレイピング。Qiita APIでは取得できないため）
-  - `items`: 投稿記事数（Qiita API）
+  - `followers`: フォロワー数(Qiita API)
+  - `contributions`: Contribution数(メンバーページのスクレイピング。Qiita APIでは取得できないため)
+  - `items`: 投稿記事数(メンバーページのスクレイピング)
 
   ```shell
   Total members in sigma organization: 4
@@ -48,7 +48,7 @@ QiitaのOrganizationsのデータを集めるプロジェクト
 
 1. [Nix](https://nixos.org/download/) をインストールし、flakesを有効化する。
 
-2. `followers` / `items` 指標を使う場合は `.env` に `QIITA_API_KEY` を設定する（`contributions` 指標はスクレイピングのためAPI keyは不要）。
+2. `followers` 指標を使う場合は `.env` に `QIITA_API_KEY` を設定する(`contributions` / `items` 指標はメンバーページのスクレイピングのためAPI keyは不要)。
 
   ```shell
   cat << EOF > org_ranker/.env
@@ -79,7 +79,7 @@ deno task contributions <organization_name>
 deno task items <organization_name>
 ```
 
-`contributions` はプロフィールページのスクレイピングのみで取得するため `--allow-net` だけで動作する。`followers` / `items` は Qiita API key を `.env` から読み込むため `--allow-env --allow-read` も付与している (タスク定義済み)。
+`contributions` / `items` はメンバーページのスクレイピングのみで取得するため `--allow-net` だけで動作する。`followers` は Qiita API key を `.env` から読み込むため `--allow-env --allow-read` も付与している (タスク定義済み)。
 
 ---
 

--- a/org_ranker/deno.json
+++ b/org_ranker/deno.json
@@ -1,12 +1,25 @@
 {
   "tasks": {
-    "dev": "deno run --watch main.ts",
-    "contributions": "deno run --allow-net main.ts contributions",
-    "followers": "deno run --allow-net --allow-env --allow-read main.ts followers",
-    "items": "deno run --allow-net --allow-env --allow-read main.ts items",
-    "test": "deno test --allow-net --allow-env"
+    "contributions": {
+      "description": "Contribution数で組織メンバーをランキングする(引数: <org_name>)",
+      "command": "deno run --allow-net main.ts contributions"
+    },
+    "followers": {
+      "description": "フォロワー数で組織メンバーをランキングする(要QIITA_API_KEY。引数: <org_name>)",
+      "command": "deno run --allow-net --allow-env --allow-read main.ts followers"
+    },
+    "items": {
+      "description": "投稿記事数で組織メンバーをランキングする(引数: <org_name>)",
+      "command": "deno run --allow-net main.ts items"
+    },
+    "test": {
+      "description": "テストを実行する",
+      "command": "deno test"
+    }
   },
   "imports": {
-    "@std/assert": "jsr:@std/assert@1"
+    "@std/assert": "jsr:@std/assert@1",
+    "@std/dotenv": "jsr:@std/dotenv@^0.225.5",
+    "@std/path": "jsr:@std/path@^1"
   }
 }

--- a/org_ranker/deno.lock
+++ b/org_ranker/deno.lock
@@ -1,18 +1,40 @@
 {
-  "version": "4",
+  "version": "5",
   "specifiers": {
-    "jsr:@std/assert@1": "1.0.11",
-    "jsr:@std/internal@^1.0.5": "1.0.5"
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/dotenv@~0.225.5": "0.225.7",
+    "jsr:@std/internal@^1.0.12": "1.0.14",
+    "jsr:@std/internal@^1.0.14": "1.0.14",
+    "jsr:@std/internal@^1.0.5": "1.0.5",
+    "jsr:@std/path@1": "1.1.6"
   },
   "jsr": {
     "@std/assert@1.0.11": {
       "integrity": "2461ef3c368fe88bc60e186e7744a93112f16fd110022e113a0849e94d1c83c1",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.5"
       ]
+    },
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
+      ]
+    },
+    "@std/dotenv@0.225.7": {
+      "integrity": "11d8db03ca4ad5aba9eba809f2e8058b2a4f320b7b09fea4b360e162928329e3"
     },
     "@std/internal@1.0.5": {
       "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
+    },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    },
+    "@std/path@1.1.6": {
+      "integrity": "c68485c2a4dfbb5ae3cc74fae4e8c4e5d874cf8a8ed12927917235c758b46cbe",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.14"
+      ]
     }
   },
   "redirects": {
@@ -105,7 +127,9 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@std/assert@1"
+      "jsr:@std/assert@1",
+      "jsr:@std/dotenv@~0.225.5",
+      "jsr:@std/path@1"
     ]
   }
 }

--- a/org_ranker/main.ts
+++ b/org_ranker/main.ts
@@ -1,14 +1,11 @@
-import {
-  fetchQiitaOrgUsers,
-  fetchQiitaUserContribution,
-} from "./qiitaScrape.ts";
-import { fetchQiitaUserStats, getQiitaApiKey } from "./qiitaApi.ts";
+import { fetchQiitaOrgMembers, OrgMember } from "./qiitaScrape.ts";
+import { fetchQiitaUserFollowers, getQiitaApiKey } from "./qiitaApi.ts";
 
 /**
  * ランキングの集計対象となる指標。
- * - followers: フォロワー数（Qiita API）
- * - contributions: Contribution数（プロフィールページのスクレイピング）
- * - items: 投稿記事数（Qiita API）
+ * - followers: フォロワー数(Qiita API)
+ * - contributions: Contribution数(メンバーページのスクレイピング)
+ * - items: 投稿記事数(メンバーページのスクレイピング)
  */
 type Metric = "followers" | "contributions" | "items";
 
@@ -19,12 +16,10 @@ const METRIC_LABELS: Record<Metric, string> = {
   items: "article count",
 };
 
-/**
- * Contribution数はスクレイピングで取得するためAPI keyを必要としない。
- * followers / items はQiita APIを利用するためAPI keyが必要。
- */
-function requiresApiKey(metric: Metric): boolean {
-  return metric !== "contributions";
+/** ランキング1件分(ユーザー名とカウント) */
+interface RankedUser {
+  username: string;
+  count: number;
 }
 
 /**
@@ -41,56 +36,75 @@ function parseMetric(value: string): Metric {
   );
 }
 
-/**
- * 指定した指標について、ユーザーのカウントを取得します。
- * @param metric 集計対象の指標
- * @param apiKey Qiita API key（contributionsの場合はnull可）
- * @param username Qiitaのユーザー名
- * @returns 指標のカウント
- */
-async function fetchCount(
-  metric: Metric,
-  apiKey: string | null,
-  username: string,
-): Promise<number> {
-  if (metric === "contributions") {
-    return await fetchQiitaUserContribution(username);
-  }
+/** 使い方(--help)を表示します。 */
+function printHelp(): void {
+  console.log(
+    `Qiita Organizations Ranker
 
-  const stats = await fetchQiitaUserStats(apiKey ?? "", username);
-  return metric === "followers" ? stats.followersCount : stats.itemsCount;
+Usage: deno run --allow-net [--allow-env --allow-read] main.ts <metric> <org_name>
+
+Arguments:
+  metric    集計対象の指標: followers | contributions | items
+  org_name  Qiita組織の名前(URLの一部)
+
+Metrics:
+  followers      フォロワー数(Qiita API。QIITA_API_KEYが必要)
+  contributions  Contribution数(メンバーページのスクレイピング)
+  items          投稿記事数(メンバーページのスクレイピング)
+
+Options:
+  -h, --help  このヘルプを表示する
+
+Examples:
+  deno task followers <org_name>
+  deno task contributions <org_name>
+  deno task items <org_name>`,
+  );
 }
 
 /**
- * QiitaのOrganizationsからユーザー名一覧を取得します。
- * @param orgName Qiita組織の名前（URLの一部）
- * @returns ユーザー名（文字列）の配列を解決するPromise
+ * followers指標について、各メンバーのフォロワー数をQiita APIで取得します。
+ * 取得に失敗したユーザーはランキングに含めず、失敗ユーザー名の配列に集めます。
+ * @param members 集計対象のメンバー一覧
+ * @param apiKey 検証済みのQiita API key
+ * @returns ランキング対象ユーザーと、取得に失敗したユーザー名
  */
-async function listQiitaOrgMembers(orgName: string): Promise<string[]> {
-  try {
-    const usernames = await fetchQiitaOrgUsers(orgName);
-    console.log(
-      `Total members in ${orgName} organization: ${usernames.length}`,
-    );
-    return usernames;
-  } catch (error) {
-    if (error instanceof Error) {
-      console.error(`Error fetching organization members: ${error.message}`);
-    } else {
-      console.error(`Error fetching organization members: ${String(error)}`);
+async function rankByFollowers(
+  members: OrgMember[],
+  apiKey: string,
+): Promise<{ ranked: RankedUser[]; failed: string[] }> {
+  const ranked: RankedUser[] = [];
+  const failed: string[] = [];
+  for (const member of members) {
+    try {
+      const count = await fetchQiitaUserFollowers(apiKey, member.urlName);
+      ranked.push({ username: member.urlName, count });
+    } catch (error) {
+      console.error(
+        `Error fetching ${member.urlName}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      failed.push(member.urlName);
     }
-    return [];
   }
+  return { ranked, failed };
 }
 
 if (import.meta.main) {
-  // 実行時の引数でOrganization名と指標を取得
   const args = Deno.args;
+
+  if (args.includes("-h") || args.includes("--help")) {
+    printHelp();
+    Deno.exit(0);
+  }
+
   if (args.length !== 2) {
     console.error(
       "Usage: deno run --allow-net [--allow-env --allow-read] main.ts <metric> <org_name>",
     );
     console.error("  metric: followers | contributions | items");
+    console.error("Run with --help for details.");
     Deno.exit(1);
   }
 
@@ -103,44 +117,70 @@ if (import.meta.main) {
   }
   const orgName = args[1];
 
-  const usernames = await listQiitaOrgMembers(orgName);
-
-  // followers / items の場合のみQiita API keyを取得
-  let apiKey: string | null = null;
-  if (requiresApiKey(metric)) {
-    try {
-      apiKey = await getQiitaApiKey();
-      if (!apiKey || typeof apiKey !== "string" || apiKey.trim() === "") {
-        throw new Error("Invalid or empty API key received");
-      }
-    } catch (error) {
-      console.error(`Failed to get valid API key: ${error}`);
-      Deno.exit(1);
-    }
+  // メンバー一覧を取得(ユーザー名・Contribution数・記事数を含む)
+  let members: OrgMember[];
+  try {
+    members = await fetchQiitaOrgMembers(orgName);
+  } catch (error) {
+    console.error(
+      `Error fetching organization members: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    Deno.exit(1);
   }
 
-  // 各ユーザーのカウントとユーザー名のペアを作成
-  const userCounts: { username: string; count: number }[] = [];
-  for (const username of usernames) {
+  console.log(`Total members in ${orgName} organization: ${members.length}`);
+  if (members.length === 0) {
+    console.error(
+      `No members found for organization "${orgName}". Check the organization name.`,
+    );
+    Deno.exit(1);
+  }
+
+  let ranked: RankedUser[];
+  let failed: string[] = [];
+
+  if (metric === "contributions") {
+    ranked = members.map((m) => ({
+      username: m.urlName,
+      count: m.contribution,
+    }));
+  } else if (metric === "items") {
+    ranked = members.map((m) => ({
+      username: m.urlName,
+      count: m.articlesCount,
+    }));
+  } else {
+    // followersのみQiita APIで取得
+    let apiKey: string;
     try {
-      const count = await fetchCount(metric, apiKey, username);
-      userCounts.push({ username, count });
+      apiKey = await getQiitaApiKey();
     } catch (error) {
-      console.error(`Error processing user ${username}: ${error}`);
-      // Add with zero count and continue with next user
-      userCounts.push({ username, count: 0 });
+      console.error(
+        `Failed to get valid API key: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      Deno.exit(1);
     }
+    ({ ranked, failed } = await rankByFollowers(members, apiKey));
   }
 
   // カウントの多い順にソート
-  userCounts.sort((a, b) => b.count - a.count);
+  ranked.sort((a, b) => b.count - a.count);
 
   // ソート結果を表示
   const label = METRIC_LABELS[metric];
   console.log(`\nUsers ranked by ${label}:`);
-  userCounts.forEach((user, index) => {
+  ranked.forEach((user, index) => {
     console.log(
       `${index + 1}. User: ${user.username}, ${label}: ${user.count}`,
     );
   });
+
+  // 取得に失敗したユーザーは順位から除外し、末尾でまとめて報告する
+  if (failed.length > 0) {
+    console.log(`\nFailed to fetch (${failed.length}): ${failed.join(", ")}`);
+  }
 }

--- a/org_ranker/main_test.ts
+++ b/org_ranker/main_test.ts
@@ -1,18 +1,58 @@
 import { assertEquals } from "@std/assert";
-import { extractContributionFromHtml } from "./qiitaScrape.ts";
+import { extractMembersFromHtml } from "./qiitaScrape.ts";
 
-Deno.test("extractContributionFromHtml: プロフィールページのJSONからcontributionを抽出する", () => {
-  const json = JSON.stringify({ user: { contribution: 32847 } });
+Deno.test("extractMembersFromHtml: メンバーページのJSONからContribution数と記事数を抽出する", () => {
+  const json = JSON.stringify({
+    organization: {
+      paginatedMemberships: {
+        items: [
+          {
+            user: {
+              urlName: "alice",
+              contribution: 100,
+              articles: { totalCount: 5 },
+            },
+          },
+          {
+            user: {
+              urlName: "bob",
+              contribution: 50,
+              articles: { totalCount: 3 },
+            },
+          },
+        ],
+        pageData: { totalPages: 2 },
+      },
+    },
+  });
   const html =
-    `<script type="application/json" class="js-react-on-rails-component" data-component-name="UserMainPage" data-dom-id="UserMainPage-react-component-xxxx">${json}</script>`;
+    `<script type="application/json" data-component-name="OrganizationMembershipsIndexPage">${json}</script>`;
 
-  assertEquals(extractContributionFromHtml(html), 32847);
+  const result = extractMembersFromHtml(html);
+  assertEquals(result.totalPages, 2);
+  assertEquals(result.members, [
+    { urlName: "alice", contribution: 100, articlesCount: 5 },
+    { urlName: "bob", contribution: 50, articlesCount: 3 },
+  ]);
 });
 
-Deno.test("extractContributionFromHtml: contributionが無い場合は0を返す", () => {
-  const json = JSON.stringify({ user: { followersCount: 10 } });
-  const html =
-    `<script data-component-name="UserMainPage" data-dom-id="x">${json}</script>`;
+Deno.test("extractMembersFromHtml: 欠けているフィールドは0で補い、urlNameが無いユーザーは除外する", () => {
+  const json = JSON.stringify({
+    organization: {
+      paginatedMemberships: {
+        items: [
+          { user: { urlName: "carol" } },
+          { user: { profileImageUrl: "https://example.com/x.png" } },
+        ],
+      },
+    },
+  });
+  const html = `<script data-component-name="x">${json}</script>`;
 
-  assertEquals(extractContributionFromHtml(html), 0);
+  const result = extractMembersFromHtml(html);
+  // totalPagesの指定が無い場合は1にフォールバックする
+  assertEquals(result.totalPages, 1);
+  assertEquals(result.members, [
+    { urlName: "carol", contribution: 0, articlesCount: 0 },
+  ]);
 });

--- a/org_ranker/qiitaApi.ts
+++ b/org_ranker/qiitaApi.ts
@@ -1,8 +1,13 @@
-import { load } from "https://deno.land/std/dotenv/mod.ts";
-import { dirname, fromFileUrl, join } from "https://deno.land/std/path/mod.ts";
+import { load } from "@std/dotenv";
+import { dirname, fromFileUrl, join } from "@std/path";
 
 /**
- * QiitaのAPI keyを取得するための関数
+ * QiitaのAPI keyを取得します。
+ *
+ * `.env` または環境変数から読み込み、未設定・空文字の場合はエラーにします。
+ * これによりAPI keyの検証はこの関数に一元化され、呼び出し側は有効なkeyが
+ * 返ることを前提にできます。
+ * @returns 検証済みのAPI key
  */
 export async function getQiitaApiKey(): Promise<string> {
   // .envファイルの絶対パスを構築
@@ -13,7 +18,7 @@ export async function getQiitaApiKey(): Promise<string> {
   const env = await load({ envPath });
   const apiKey = env["QIITA_API_KEY"] || Deno.env.get("QIITA_API_KEY");
 
-  if (!apiKey) {
+  if (!apiKey || apiKey.trim() === "") {
     throw new Error(
       "QIITA_API_KEY is not set in the .env file or environment variables.",
     );
@@ -22,44 +27,28 @@ export async function getQiitaApiKey(): Promise<string> {
 }
 
 /**
- * Qiita APIで取得するユーザーの統計情報
+ * Qiita APIを使用してユーザーのフォロワー数を取得します。
+ *
+ * 取得に失敗した場合は例外を投げます(呼び出し側で失敗ユーザーを
+ * ランキングから除外できるようにするため、0でフォールバックしません)。
+ * @param apiKey 検証済みのQiita API key
+ * @param username Qiitaのユーザー名
+ * @returns フォロワー数
  */
-export interface QiitaUserStats {
-  /** フォロワー数 */
-  followersCount: number;
-  /** 投稿記事数 */
-  itemsCount: number;
-}
-
-/**
- * Qiita APIを使用してユーザーの統計情報（フォロワー数・記事数）を取得する関数
- */
-export async function fetchQiitaUserStats(
+export async function fetchQiitaUserFollowers(
   apiKey: string,
   username: string,
-): Promise<QiitaUserStats> {
-  // Validate apiKey to ensure it's a non-empty string
-  if (!apiKey || typeof apiKey !== "string" || apiKey.trim() === "") {
-    console.error(`Invalid API key provided for user ${username}`);
-    return { followersCount: 0, itemsCount: 0 };
-  }
-
+): Promise<number> {
   const url = `https://qiita.com/api/v2/users/${username}`;
   const headers = new Headers();
   headers.append("Authorization", `Bearer ${apiKey}`);
 
-  try {
-    const response = await fetch(url, { headers });
-    if (!response.ok) {
-      throw new Error(`Failed to fetch user information: ${response.status}`);
-    }
-    const userData = await response.json();
-    return {
-      followersCount: userData.followers_count || 0,
-      itemsCount: userData.items_count || 0,
-    };
-  } catch (error) {
-    console.error(`Error fetching user stats: ${error}`);
-    return { followersCount: 0, itemsCount: 0 };
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch user ${username}: ${response.status} ${response.statusText}`,
+    );
   }
+  const userData = await response.json();
+  return userData.followers_count ?? 0;
 }

--- a/org_ranker/qiitaScrape.ts
+++ b/org_ranker/qiitaScrape.ts
@@ -1,126 +1,87 @@
 /**
- * QiitaのOrganizationsからユーザー一覧を取得します。
- * @param orgName Qiita組織の名前（URLの一部）
- * @returns メンバーのユーザー名の配列を解決するPromise
+ * Qiita組織メンバーの情報。メンバーページに埋め込まれたJSONから取得する。
  */
-export async function fetchQiitaOrgUsers(orgName: string): Promise<string[]> {
+export interface OrgMember {
+  /** ユーザー名(URLの一部) */
+  urlName: string;
+  /** Contribution数 */
+  contribution: number;
+  /** 投稿記事数 */
+  articlesCount: number;
+}
+
+/**
+ * メンバーページ1ページ分の抽出結果。
+ */
+export interface MembersPage {
+  /** そのページに含まれるメンバー一覧 */
+  members: OrgMember[];
+  /** メンバー一覧全体のページ数 */
+  totalPages: number;
+}
+
+/**
+ * QiitaのOrganizationsから全メンバーの情報を取得します。
+ *
+ * メンバーページ( https://qiita.com/organizations/<org>/members )に埋め込まれた
+ * JSONにはユーザー名・Contribution数・投稿記事数が含まれるため、ユーザーごとに
+ * プロフィールページやAPIを叩かずに集計に必要な情報がまとめて得られます。
+ * 一覧はページングされるため、1ページ目の`totalPages`を見て全ページを取得します。
+ * @param orgName Qiita組織の名前(URLの一部)
+ * @returns 全メンバーの情報の配列を解決するPromise
+ */
+export async function fetchQiitaOrgMembers(
+  orgName: string,
+): Promise<OrgMember[]> {
   if (!orgName) {
     throw new Error("Organization name is required");
   }
 
-  const url = `https://qiita.com/organizations/${orgName}/members`;
-
-  try {
-    const response = await fetch(url);
-    if (!response.ok) {
-      throw new Error(
-        `Failed to fetch organization page: ${response.status} ${response.statusText}`,
-      );
-    }
-
-    const html = await response.text();
-    const data = extractJsonFromHtml(html);
-
-    if (
-      data.organization && data.organization.memberships &&
-      data.organization.memberships.edges
-    ) {
-      return data.organization.memberships.edges
-        .map((edge: any) => edge.node.user.urlName)
-        .filter((name: string | null) => name !== null);
-    } else {
-      console.warn("JSON data was not in the expected format");
-      return [];
-    }
-  } catch (error) {
-    if (error instanceof Error) {
-      console.error(
-        `Error fetching Qiita organization members: ${error.message}`,
-      );
-    } else {
-      console.error(
-        `Error fetching Qiita organization members: ${String(error)}`,
-      );
-    }
-    return [];
+  const firstPage = await fetchMembersPage(orgName, 1);
+  const members = [...firstPage.members];
+  for (let page = 2; page <= firstPage.totalPages; page++) {
+    const nextPage = await fetchMembersPage(orgName, page);
+    members.push(...nextPage.members);
   }
+  return members;
 }
 
 /**
- * QiitaのユーザープロフィールページをスクレイピングしてContribution数を取得します。
- *
- * Contribution数はQiita APIでは取得できないため、プロフィールページ
- * （ https://qiita.com/<username> ）に埋め込まれたJSONから抽出します。
- * @param username Qiitaのユーザー名
- * @returns Contribution数を解決するPromise
+ * メンバーページを1ページ取得し、埋め込みJSONからメンバー情報を抽出します。
+ * @param orgName Qiita組織の名前(URLの一部)
+ * @param page 取得するページ番号(1始まり)
+ * @returns そのページのメンバー情報とページ数
  */
-export async function fetchQiitaUserContribution(
-  username: string,
-): Promise<number> {
-  if (!username) {
-    throw new Error("Username is required");
-  }
+async function fetchMembersPage(
+  orgName: string,
+  page: number,
+): Promise<MembersPage> {
+  const url = `https://qiita.com/organizations/${orgName}/members?page=${page}`;
 
-  const url = `https://qiita.com/${username}`;
-
-  try {
-    const response = await fetch(url);
-    if (!response.ok) {
-      throw new Error(
-        `Failed to fetch user page: ${response.status} ${response.statusText}`,
-      );
-    }
-
-    const html = await response.text();
-    return extractContributionFromHtml(html);
-  } catch (error) {
-    if (error instanceof Error) {
-      console.error(`Error fetching Qiita user contribution: ${error.message}`);
-    } else {
-      console.error(`Error fetching Qiita user contribution: ${String(error)}`);
-    }
-    return 0;
-  }
-}
-
-/**
- * ユーザープロフィールページのHTMLからContribution数を抽出するhelper。
- *
- * プロフィールページにはReact用のJSONが
- * `<script data-component-name="UserMainPage" ...>...</script>`
- * の形で埋め込まれており、その中の `user.contribution` を利用します。
- * @param html 解析対象のHTML文字列
- * @returns Contribution数
- */
-export function extractContributionFromHtml(html: string): number {
-  const jsonMatch = html.match(
-    /data-component-name="UserMainPage"[^>]*>(.*?)<\/script>/s,
-  );
-
-  if (!jsonMatch) {
-    throw new Error("Could not find JSON data containing user contribution");
-  }
-
-  try {
-    const data = JSON.parse(jsonMatch[1]);
-    return data.user?.contribution ?? 0;
-  } catch (jsonError) {
+  const response = await fetch(url);
+  if (!response.ok) {
     throw new Error(
-      `Failed to parse JSON: ${
-        jsonError instanceof Error ? jsonError.message : String(jsonError)
-      }`,
+      `Failed to fetch organization page: ${response.status} ${response.statusText}`,
     );
   }
+
+  const html = await response.text();
+  return extractMembersFromHtml(html);
 }
 
 /**
- * HTML内に含まれるJSON形式のデータを抽出してパースするhelper
+ * メンバーページのHTMLからメンバー情報とページ数を抽出するhelper。
+ *
+ * メンバーページにはReact用のJSONが埋め込まれており、
+ * `organization.paginatedMemberships.items[].user` に各メンバーの
+ * `urlName` / `contribution` / `articles.totalCount` が、
+ * `organization.paginatedMemberships.pageData.totalPages` にページ数が入っています。
  * @param html 解析対象のHTML文字列
- * @returns パースされたJSONオブジェクト
+ * @returns メンバー情報とページ数
  */
-function extractJsonFromHtml(html: string): any {
+export function extractMembersFromHtml(html: string): MembersPage {
   const jsonMatch = html.match(
-    /{\"organization\":{\"paginatedMemberships.*?<\/script>/s,
+    /{"organization":{"paginatedMemberships.*?<\/script>/s,
   );
 
   if (!jsonMatch) {
@@ -129,10 +90,24 @@ function extractJsonFromHtml(html: string): any {
     );
   }
 
-  const jsonStr = jsonMatch[0].replace(/<\/script>$/g, "");
+  const jsonStr = jsonMatch[0].replace(/<\/script>$/, "");
 
+  let data: {
+    organization?: {
+      paginatedMemberships?: {
+        items?: {
+          user?: {
+            urlName?: string | null;
+            contribution?: number;
+            articles?: { totalCount?: number };
+          };
+        }[];
+        pageData?: { totalPages?: number };
+      };
+    };
+  };
   try {
-    return JSON.parse(jsonStr);
+    data = JSON.parse(jsonStr);
   } catch (jsonError) {
     throw new Error(
       `Failed to parse JSON: ${
@@ -140,4 +115,23 @@ function extractJsonFromHtml(html: string): any {
       }`,
     );
   }
+
+  const paginated = data.organization?.paginatedMemberships;
+  if (!paginated || !Array.isArray(paginated.items)) {
+    throw new Error("JSON data was not in the expected format");
+  }
+
+  const members: OrgMember[] = paginated.items
+    .map((item) => item.user)
+    .filter((user): user is NonNullable<typeof user> =>
+      user != null && typeof user.urlName === "string"
+    )
+    .map((user) => ({
+      urlName: user.urlName as string,
+      contribution: user.contribution ?? 0,
+      articlesCount: user.articles?.totalCount ?? 0,
+    }));
+
+  const totalPages = paginated.pageData?.totalPages ?? 1;
+  return { members, totalPages };
 }


### PR DESCRIPTION
メンバーページの埋め込みJSONにContribution数と記事数が含まれるため、
contributions/itemsはユーザーごとのリクエストを廃止しメンバーページの
取得のみで集計する。itemsはAPI key不要になった。followersのみQiita API
を使い、取得失敗ユーザーは0扱いせずランキングから除外して末尾で報告する。

- API keyの検証をgetQiitaApiKey()に一元化
- --help / -h を追加
- deno taskに説明を付与し一覧表示に対応(壊れていたdevタスクは削除)
- std依存をdeno.landのURLからJSR(import map)へ移行
- extractMembersFromHtml向けにテストを更新

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

# Change Description

## Reference

- [Issue link](example.com) <!-- replace to issue link -->
